### PR TITLE
fix "beelte" typo in button tooltip

### DIFF
--- a/generator/index.html
+++ b/generator/index.html
@@ -30,7 +30,7 @@
           <button id="shirtbutton" onclick="chooseDesign()"><img class="icon" src="icons8-jumper-50.png"
               alt="print on shirt" title="print on shirt"></button>
           <button id="cyclebutton" onclick="toggleLoop()"><img class="icon" src="icons8-next-80.png"
-              alt="animate beelte" title="animate beelte"></button>
+              alt="animate beetle" title="animate beetle"></button>
           <button id="refresh" onclick="makeNewBeetle()"><img class="icon" src="icons8-neu-64.png" alt="new beetle"
               title="new beetle"></button>
           <button id="seed" onclick="saveBeetle()"><img class="icon" src="icons8-save-50.png" alt="permalink"


### PR DESCRIPTION
Fixes a minor typo in the tooltip of the "animate beetle" button, which is currently labeled as "animate beelte" :blush: 