### PR TITLE
Add Rebecca Purple

### DIFF
--- a/generator/color.js
+++ b/generator/color.js
@@ -595,6 +595,7 @@ var ntc = {
 ["660099", "Purple"],
 ["66023C", "Tyrian Purple"],
 ["661010", "Dark Tan"],
+["663399", "Rebecca Purple"],
 ["66B58F", "Silver Tree"],
 ["66FF00", "Bright Green"],
 ["66FF66", "Screamin' Green"],


### PR DESCRIPTION
The CSS color rebeccapurple, part of CSS Color Level 4, is named in memory of Rebecca Alison Meyer, daughter of web pioneer Eric Meyer.

https://meyerweb.com/eric/thoughts/2014/06/19/rebeccapurple/